### PR TITLE
add X-Api-Version: 2020-06-15

### DIFF
--- a/dist/コード.js
+++ b/dist/コード.js
@@ -64,7 +64,8 @@ function runMethod(obj) {
     "method": method,
     "contentType": "application/json",
     "headers": { 
-      "Authorization": "Bearer " + access_token
+      "Authorization": "Bearer " + access_token,
+      "X-Api-Version": 2020-06-15
     },
     "payload": payload,
     "muteHttpExceptions": true


### PR DESCRIPTION
freeeの仕様変更に対応。

リクエストヘッダーに "X-Api-Version": 2020-06-15 を追加して新バージョンのAPIを利用できるようにする。

<hr>
FYI

https://developer.freee.co.jp/docs/accounting/reference
![スクリーンショット 2020-06-25 22 31 34](https://user-images.githubusercontent.com/5506377/85729346-b0769d00-b733-11ea-84bc-a87590feaf5c.png)



https://developer.freee.co.jp/release-note/2948
![スクリーンショット 2020-06-25 22 35 06](https://user-images.githubusercontent.com/5506377/85729880-2418aa00-b734-11ea-9032-e49e0752257d.png)
