### PR TITLE
redirect_uriをPropertyから呼び出すように変更する

### DIFF
--- a/dist/appsscript.json
+++ b/dist/appsscript.json
@@ -1,9 +1,10 @@
 {
   "timeZone": "Asia/Tokyo",
-  "dependencies": {},
+  "dependencies": {
+  },
   "webapp": {
-    "executeAs": "USER_ACCESSING",
-    "access": "ANYONE"
+    "access": "ANYONE",
+    "executeAs": "USER_ACCESSING"
   },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8"

--- a/dist/index.html
+++ b/dist/index.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     freee API Playground
-    <a id="version" target ="_blank" href="https://github.com/satoshixsea/freee-API-Playground/pull/13">GitHub</a>
+    <a id="version" target ="_blank" href="https://github.com/satoshixsea/freee-API-Playground/pull/15">GitHub</a>
     <br><br>
     <button id="refresh_token">token refresh</button>
     <button id="show_accesstoken">your accesstoken</button>

--- a/dist/コード.js
+++ b/dist/コード.js
@@ -1,7 +1,7 @@
 const token_url = "https://accounts.secure.freee.co.jp/public_api/token";
 const client_id = getScriptProperty("client_id");
 const client_secret = getScriptProperty("client_secret");
-const redirect_uri =returnAppUrl();
+const redirect_uri = returnAppUrl();
 
 function returnAppUrl() {// success.htmlでも呼ぶので関数にしておく
   returngetScriptProperty("redirect_uri");// このスクリプトのWebアプリのURL

--- a/dist/コード.js
+++ b/dist/コード.js
@@ -1,10 +1,10 @@
 const token_url = "https://accounts.secure.freee.co.jp/public_api/token";
 const client_id = getScriptProperty("client_id");
 const client_secret = getScriptProperty("client_secret");
-const redirect_uri = returnAppUrl();
+const redirect_uri =returnAppUrl();
 
 function returnAppUrl() {// success.htmlでも呼ぶので関数にしておく
-  return ScriptApp.getService().getUrl();// このスクリプトのWebアプリのURL
+  returngetScriptProperty("redirect_uri");// このスクリプトのWebアプリのURL
 }
 
 function doGet(e) {


### PR DESCRIPTION
`ScriptApp.getService().getUrl()` だとGoogle Workspaceを使っているアカウントで以下のようなエラーが発生してアクセストークンが取得できない。

`Exception: https://accounts.secure.freee.co.jp のリクエストに失敗しました（エラー: 401）。サーバー応答の一部: {"error":"invalid_grant","error_description":"指定された認可グラントは不正か、有効期限切れか、無効か、リダイレクトURIが異なるか、もしくは別のクライアントに適用されています。"}（応答の全文を見るには muteHttpExceptions オプションを使用してください）（行 36、ファイル「コード」）`

<img width="1071" alt="スクリーンショット 2021-11-20 14 33 57" src="https://user-images.githubusercontent.com/65533669/142715717-d88b41d1-db87-4a2a-9c29-8de2e2fe16c5.png">


これを回避するため、アプリストア側に登録しているコールバックURLをGASのプロパティに入れて呼び出すように変更する。
これによってコード内のredirect_uriを固定し、上記のエラーを回避する。